### PR TITLE
feat: warn when advancing into match with no starting XI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,6 +246,7 @@ function FootballManager() {
   const [tradesMadeInWindow, setTradesMadeInWindow] = useState(0); // trades in current transfer window
   const [tradedWithClubs, setTradedWithClubs] = useState(new Set()); // clubs traded with (for Old Boys Network)
   const [startingXI, setStartingXI] = useState([]);
+  const [showLineupWarning, setShowLineupWarning] = useState(false);
   const [bench, setBench] = useState([]);
   const [dragPlayer, setDragPlayer] = useState(null);
   const [isMobile, setIsMobile] = useState(() => typeof window !== "undefined" && window.innerWidth <= 768);
@@ -4278,6 +4279,11 @@ function FootballManager() {
               {matchPending ? (
                 <button
                   onClick={() => {
+                    // Starting XI warning: block if no lineup assigned
+                    if (!startingXI || startingXI.length === 0) {
+                      setShowLineupWarning(true);
+                      return;
+                    }
                     // Altitude Trials: enforce minimum ATK players
                     const atkMod = getModifier(leagueTier);
                     if (atkMod.minAtkPlayers) {
@@ -4413,7 +4419,15 @@ function FootballManager() {
                 </button>
               ) : (
                 <button
-                  onClick={advanceWeek}
+                  onClick={() => {
+                    const nextEntry = seasonCalendar?.[calendarIndex + 1];
+                    const nextIsMatch = nextEntry && ["league", "cup", "dynasty", "mini"].includes(nextEntry.type);
+                    if (nextIsMatch && (!startingXI || startingXI.length === 0)) {
+                      setShowLineupWarning(true);
+                      return;
+                    }
+                    advanceWeek();
+                  }}
                   disabled={isDisabled}
                   style={{
                     background: isDisabled ? "rgba(30,41,59,0.5)" : "linear-gradient(180deg, #166534, #14532d)",
@@ -6830,6 +6844,18 @@ function FootballManager() {
         ultimatumTarget={ultimatumTarget}
         ultimatumGamesLeft={ultimatumGamesLeft}
         gameMode={gameMode}
+        showLineupWarning={showLineupWarning}
+        onDismissLineupWarning={() => setShowLineupWarning(false)}
+        onLineupWarningGoToSquad={() => {
+          setShowLineupWarning(false);
+          setShowAchievements(false); setShowTable(false); setShowCalendar(false);
+          setShowCup(false); setShowTransfers(false); setShowLegends(false);
+          setShowSquad(true);
+        }}
+        onLineupWarningPlayAnyway={() => {
+          setShowLineupWarning(false);
+          advanceWeek();
+        }}
       />
       )}
 

--- a/src/components/ui/Dashboard.jsx
+++ b/src/components/ui/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { F, C, FONT, Z } from "../../data/tokens";
+import { F, C, FONT, Z, MODAL } from "../../data/tokens";
 import { POS_COLORS } from "../../data/positions.js";
 import { LEAGUE_DEFS, NUM_TIERS } from "../../data/leagues.js";
 import { getEffectiveSlots, detectFormationName } from "../../utils/formation.js";
@@ -19,6 +19,7 @@ export function Dashboard({
   fanSentiment = 50, boardSentiment = 50,
   ultimatumActive = false, ultimatumPtsEarned = 0, ultimatumTarget = 0, ultimatumGamesLeft = 0,
   gameMode = "casual",
+  showLineupWarning = false, onDismissLineupWarning, onLineupWarningGoToSquad, onLineupWarningPlayAnyway,
 }) {
   const mob = isMobile;
 
@@ -836,6 +837,64 @@ export function Dashboard({
         </div>
       </div>
       </div>{/* end newspaper frame */}
+
+      {/* ═══ LINEUP WARNING MODAL ═══ */}
+      {showLineupWarning && (
+        <div style={{ ...MODAL.backdrop, zIndex: Z.confirm }}>
+          <div style={{
+            ...MODAL.box,
+            border: `3px solid ${C.amber}`,
+            padding: mob ? "30px 20px" : "40px 44px",
+            width: mob ? "90%" : "auto",
+            boxShadow: "0 0 50px rgba(251,191,36,0.25), inset 0 0 80px rgba(0,0,0,0.6)",
+          }}>
+            <div style={{
+              fontSize: mob ? F.md : F.lg,
+              color: C.amber,
+              marginBottom: 18,
+              letterSpacing: 2,
+            }}>
+              ⚠️ NO LINEUP SET
+            </div>
+            <div style={{
+              fontSize: mob ? F.xs : F.sm,
+              color: C.text,
+              lineHeight: 1.8,
+              marginBottom: 28,
+            }}>
+              You haven't selected your starting lineup!
+              <br />
+              Go to Squad to assign players.
+            </div>
+            <div style={{ display: "flex", gap: 14, justifyContent: "center", flexWrap: "wrap" }}>
+              <button onClick={onLineupWarningGoToSquad} style={{
+                padding: mob ? "12px 20px" : "15px 30px",
+                fontSize: mob ? F.xs : F.md,
+                fontFamily: FONT,
+                background: "rgba(74,222,128,0.15)",
+                border: `2px solid ${C.green}`,
+                color: C.green,
+                cursor: "pointer",
+                letterSpacing: 1,
+              }}>
+                GO TO SQUAD
+              </button>
+              <button onClick={onLineupWarningPlayAnyway} style={{
+                padding: mob ? "12px 20px" : "15px 30px",
+                fontSize: mob ? F.xs : F.md,
+                fontFamily: FONT,
+                background: "rgba(239,68,68,0.1)",
+                border: `2px solid ${C.red}`,
+                color: C.red,
+                cursor: "pointer",
+                letterSpacing: 1,
+              }}>
+                PLAY ANYWAY
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ═══ RESULTS TICKER (fixed bottom) ═══ */}
       <div style={{


### PR DESCRIPTION
## Summary
- Adds a warning modal when the player clicks **Advance Week** (and the next calendar entry is a match) or **Play Match** with an empty starting XI
- Modal displays "You haven't selected your starting lineup! Go to Squad to assign players." with two buttons:
  - **Go to Squad** — navigates to the squad page
  - **Play Anyway** — dismisses the warning and continues
- Modal lives in the Dashboard component using existing MODAL/BTN token patterns (amber border, matches holiday confirm modal style)

## Files modified
- `src/App.jsx` — added `showLineupWarning` state, intercept on Advance Week and Play Match button clicks, pass props to Dashboard
- `src/components/ui/Dashboard.jsx` — imported MODAL token, added warning modal rendering with new props

## How to test
1. Start a new game (any mode)
2. Do NOT assign any starting XI
3. Click **Advance Week** — if the next calendar entry is a match, the warning modal should appear
4. Test **Go to Squad** button navigates to squad page
5. Test **Play Anyway** button dismisses modal and advances the week
6. Also test: when a match is pending (PLAY MATCH button showing), clicking it with empty XI shows the warning
7. Verify on mobile viewport (≤768px) — modal should be responsive

## Build
⚠️ Build not verified in VM (npm registry unreachable from Cowork) — please run `npx --no vite build --mode development` locally before merging.

🤖 Generated with Claude Cowork