### PR TITLE
Fix training dropdown dismiss on outside click and Escape

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -541,6 +541,24 @@ function FootballManager() {
 
   const [pendingPlayerUnlock, setPendingPlayerUnlock] = useState(null);
   const [showAssignAll, setShowAssignAll] = useState(false);
+  const assignAllRef = useRef(null);
+  useEffect(() => {
+    if (!showAssignAll) return;
+    const handleClick = (e) => {
+      if (assignAllRef.current && !assignAllRef.current.contains(e.target)) {
+        setShowAssignAll(false);
+      }
+    };
+    const handleKey = (e) => {
+      if (e.key === "Escape") setShowAssignAll(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [showAssignAll]);
   const [squadView, setSquadView] = useState("attrs"); // "attrs" or "stats"
   const [formation, setFormation] = useState(() => DEFAULT_FORMATION.map(s => ({...s})));
   const [slotAssignments, setSlotAssignments] = useState(null); // Array(11) of playerIds or null — manual slot→player mapping
@@ -6374,7 +6392,7 @@ function FootballManager() {
                     color: squadView === "stats" ? C.blue : C.textMuted,
                     fontFamily: FONT,
                   }}>{squadView === "attrs" ? "📊 STATS" : "📋 ATTRS"}</button>
-                  <div style={{ position: "relative", display: "flex", alignItems: "center" }}>
+                  <div ref={assignAllRef} style={{ position: "relative", display: "flex", alignItems: "center" }}>
                     <button onClick={(e) => {
                       e.stopPropagation();
                       setShowAssignAll(prev => !prev);


### PR DESCRIPTION
## Summary
- Adds click-outside and Escape key handlers to the ASSIGN ALL training dropdown on the Squad page
- Dropdown now closes when clicking anywhere outside it or pressing Escape
- Uses a ref on the container div + a useEffect that only attaches listeners when the dropdown is open

Closes #6

## Test plan
- [ ] Open Squad page, click ASSIGN ALL to open training dropdown
- [ ] Click outside the dropdown — should close
- [ ] Open again, press Escape — should close
- [ ] Open again, select a training option — should still close (existing behavior preserved)
- [ ] Build passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)