### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+<!-- Root cause and what the fix/feature does. One bullet per issue if bundling small fixes. -->
+
+Closes #
+
+## Files modified
+<!-- List each file and what changed in it. -->
+- `src/file.jsx` —
+
+## Test plan
+<!-- Checkboxes for how to verify the change works. -->
+- [ ]
+- [ ]
+
+## Build confirmation
+<!-- Paste or confirm the build output. -->
+`npx vite build` passes with zero errors.


### PR DESCRIPTION
## Summary
Adds a `.github/pull_request_template.md` that auto-populates every new PR with the agreed format: summary with root cause, files modified, test plan with checkboxes, `Closes #N`, and build confirmation.

Standardises PR presentation between Trask and Calo going forward.

## Files modified
- `.github/pull_request_template.md` — new file

## Test plan
- [ ] Open a new PR on this repo — template should auto-populate in the body

## Build confirmation
No code changes — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)