### PR TITLE
Fix Asst Manager email timing and inbox button colors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1353,11 +1353,11 @@ function FootballManager() {
       ]);
       // Asst Manager intro — training onboarding
       setInboxMessages(prev => [...prev, {
-        id: "msg_asst_mgr_training_intro", week: 2, season: 1,
+        id: "msg_asst_mgr_training_intro", week: 3, season: 1,
         icon: "📋", color: "#f59e0b",
         title: "Asst. Manager's Notes",
         body: "Boss, now that we've got a match under our belt, I wanted to have a word about training.\n\nEach week, your players can be assigned a training focus — shooting, defending, pace, the lot. It's how they improve over time. Without it, they'll stay exactly where they are.\n\nYou can set it up on the Squad page, or if you'd rather focus on tactics and transfers, I'm happy to put everyone on a general programme for now. Your call.",
-        read: false, type: "asst_mgr_training_intro", pendingUntilWeek: 2,
+        read: false, type: "asst_mgr_training_intro", pendingUntilWeek: 3,
         choices: [{ label: "You Handle It", value: "delegate" }, { label: "I'll Set It Up", value: "manual" }],
       }]);
       // League modifier intro message

--- a/src/components/ui/Dashboard.jsx
+++ b/src/components/ui/Dashboard.jsx
@@ -477,8 +477,8 @@ export function Dashboard({
                   </div>
                 )}
                 {msg.choiceResult && (
-                  <div style={{ fontSize: F.xs, color: msg.choiceResult === "accept" ? C.green : C.lightRed, marginTop: 4, fontStyle: "italic" }}>
-                    {msg.choiceResult === "accept" ? "Accepted" : "Declined"}
+                  <div style={{ fontSize: F.xs, color: msg.choiceResult === "accept" ? C.green : msg.choiceResult === "decline" ? C.lightRed : C.textMuted, marginTop: 4, fontStyle: "italic" }}>
+                    {msg.choiceResult === "accept" ? "Accepted" : msg.choiceResult === "decline" ? "Declined" : (msg.choices?.find(c => c.value === msg.choiceResult)?.label || "Chosen")}
                   </div>
                 )}
                 {msg.followUp && (
@@ -486,20 +486,21 @@ export function Dashboard({
                 )}
                 {msg.choices && !msg.choiceResult && (
                   <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-                    {msg.choices.map(choice => (
-                      <button key={choice.value} onClick={() => {
+                    {msg.choices.map((choice, ci) => {
+                      const isAccept = choice.value === "accept" || choice.value === "decline" ? choice.value === "accept" : ci === 0;
+                      return <button key={choice.value} onClick={() => {
                         if (onInboxChoice && onInboxChoice(msg, choice.value) === false) return;
                         if (setInboxMessages) {
                           setInboxMessages(prev => prev.map(m => m.id === msg.id ? { ...m, choiceResult: choice.value, read: true } : m));
                         }
                       }} style={{
                         padding: "6px 10px", fontSize: F.xs, fontFamily: FONT,
-                        background: choice.value === "accept" ? "rgba(74,222,128,0.12)" : "rgba(239,68,68,0.08)",
-                        border: `1px solid ${choice.value === "accept" ? C.green : C.red}`,
-                        color: choice.value === "accept" ? C.green : C.lightRed,
+                        background: isAccept ? "rgba(74,222,128,0.12)" : "rgba(148,163,184,0.08)",
+                        border: `1px solid ${isAccept ? C.green : C.textMuted}`,
+                        color: isAccept ? C.green : C.textMuted,
                         cursor: "pointer",
-                      }}>{choice.label}</button>
-                    ))}
+                      }}>{choice.label}</button>;
+                    })}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
Closes #33

- **Email timing**: Asst Manager training intro was appearing at week 2 (after first "Advance Week"), before MD1 has been played. The body says "now that we've got a match under our belt" — but no match had happened yet. Changed `pendingUntilWeek` from 2 to 3 so it arrives after MD1.
- **Button colors**: Inbox choice buttons were hardcoded to check `choice.value === "accept"` — anything else got red "decline" styling. For the Asst Manager choices (`"delegate"` / `"manual"`), both buttons rendered red. Now the first choice gets green/primary styling and subsequent choices get neutral/muted grey.
- **Choice result label**: After making a choice, the confirmation text showed "Declined" in red for any non-`"accept"` value. Now non-standard choice values display their actual label text in muted color.

## Test plan
- [ ] Start new save → Advance Week once → inbox should NOT have Asst Manager training email yet
- [ ] Advance Week again (after MD1) → Asst Manager training email should now appear
- [ ] Check button colors: "You Handle It" should be green, "I'll Set It Up" should be grey/neutral
- [ ] Click either button → confirmation text should show the choice label, not "Declined"
- [ ] Verify trial offer buttons still work correctly (accept = green, decline = red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)