### PR TITLE
Fix export/import to use profile-scoped storage key

### DIFF
--- a/src/hooks/useSaveGame.js
+++ b/src/hooks/useSaveGame.js
@@ -20,7 +20,7 @@ export function useSaveGame({
   // Export save data as a JSON file download
   const exportSave = useCallback(async () => {
     try {
-      const result = await window.storage.get(`jfg-save-${activeSaveSlot}`);
+      const result = await window.storage.get(getSaveKey(useGameStore.getState().activeProfileId, activeSaveSlot));
       if (!result) { setImportStatus("no-save"); setTimeout(() => setImportStatus(null), 2500); return; }
       const blob = new Blob([result.value], { type: "application/json" });
       const url = URL.createObjectURL(blob);
@@ -51,7 +51,7 @@ export function useSaveGame({
         setTimeout(() => setImportStatus(null), 3000);
         return;
       }
-      await window.storage.set(`jfg-save-${activeSaveSlot}`, text);
+      await window.storage.set(getSaveKey(useGameStore.getState().activeProfileId, activeSaveSlot), text);
       setImportStatus("imported");
       setTimeout(() => {
         setImportStatus(null);


### PR DESCRIPTION
## Summary
Closes #38

`exportSave` and `importSave` in `useSaveGame.js` were using the legacy key format `jfg-save-{slot}` while save/load/delete all use `getSaveKey(profileId, slot)`. Two-line fix — both now use `getSaveKey(useGameStore.getState().activeProfileId, activeSaveSlot)`, matching `deleteSave` which was already correct.

## Test plan
- [ ] Save a game to slot 1 on a profile
- [ ] Export — should download a valid JSON file (not report "no save")
- [ ] Delete the slot
- [ ] Import the exported file
- [ ] Reload — save should appear in the correct slot
- [ ] Verify delete still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)