### PR TITLE
docs: add 12 March changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable updates to Jumpers for Goalposts, written for players.
 
 ---
 
+## 12 March 2026
+
+### Bug Fixes
+
+- **Save button feedback fixed**: The Export and Import buttons in Boot Room now show the correct status — "EXPORTED ✓" / "IMPORTED ✓" on success, "INVALID FILE" / "NO SAVE" on errors, and a loading state while the operation runs. Previously they never changed because the code was checking for status values that didn't exist.
+
+### Under the Hood
+
+- Removed duplicate colour definitions from 4 standalone screens (Mode Select, Sacking, Museum, Profile Select) — all now pull from the shared token system
+- Save export/import operations now show a loading indicator while running
+
+---
+
 ## 11 March 2026
 
 ### Improvements


### PR DESCRIPTION
## Summary
- Adds 12 March 2026 changelog entry
- Covers PRs #58 (save UI status fix) and #60 (token redefinitions)
- Player-facing language, same format as existing entries

## Test plan
- [x] Build passes
- [ ] Verify no duplicate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)