### PR TITLE
refactor: deduplicate ARC_TICKET_POOL into shared constant

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import { NATIONALITIES, NATION_NAMES, FIRST_NAMES, LAST_NAMES } from "./data/nat
 import { CUP_ROUND_MATCHWEEKS, CUP_ROUND_NAMES, CUP_DEFS } from "./data/cups.js";
 import { TIER_WIN_ACHS, ACHIEVEMENTS, LEGENDARY_ACHIEVEMENTS, PRESTIGIOUS_ACHIEVEMENTS, PLAYER_UNLOCK_ACHIEVEMENTS, UNLOCKABLE_PLAYERS } from "./data/achievements.js";
 import { LEAGUE_DEFS, NUM_TIERS, TEAM_TRAITS, AI_BENCH_POSITIONS } from "./data/leagues.js";
-import { ARC_CATS, ARC_CAT_LABELS, STORY_ARCS, ARC_NARRATIVES } from "./data/storyArcs.js";
+import { ARC_CATS, ARC_CAT_LABELS, STORY_ARCS, ARC_NARRATIVES, ARC_TICKET_POOL } from "./data/storyArcs.js";
 import { F, C, FONT, BTN, MODAL, CARD, Z } from "./data/tokens";
 import { TICKET_DEFS } from "./data/tickets.js";
 import { getModifier } from "./data/leagueModifiers.js";
@@ -2394,7 +2394,6 @@ function FootballManager() {
     let arcBoostGains = [];
     let cappedArcTickets = [];
     let juicedThisWeek = false;
-    const ARC_TICKET_POOL = ["double_session", "miracle_cream", "twelfth_man", "relation_boost", "transfer_insider", "youth_coup", "rewind", "random_attr"];
     ARC_CATS.forEach(cat => {
       const cs = arcSnap[cat];
       if (!cs || cs.completed || !cs.focus) return;
@@ -3290,7 +3289,6 @@ function FootballManager() {
     const newCompletedIds = [];
     const achievementsToUnlock = [];
 
-    const ARC_TICKET_POOL_SE = ["double_session", "miracle_cream", "twelfth_man", "relation_boost", "transfer_insider", "youth_coup", "rewind", "random_attr"];
     if (arcFx.pendingFinalRewards?.length) {
       for (const { arc, targetId, prodigalId } of arcFx.pendingFinalRewards) {
         if ((arcSnap.rewardsApplied || []).includes(arc.id)) continue;
@@ -3312,7 +3310,7 @@ function FootballManager() {
           Object.keys(p.attrs).forEach(k => { if ((p.attrs[k] || 0) > (pre[k] || 0)) gainCountSE++; });
         });
         if (intendedBoostSE && gainCountSE === 0) {
-          const shuffled = [...ARC_TICKET_POOL_SE].sort(() => Math.random() - 0.5);
+          const shuffled = [...ARC_TICKET_POOL].sort(() => Math.random() - 0.5);
           const pick = shuffled[0];
           setTickets(prev => [...prev, { id: `t_arc_se_${Date.now()}_${Math.random().toString(36).slice(2,6)}`, type: pick }]);
         }
@@ -3418,8 +3416,7 @@ function FootballManager() {
             });
           });
           if (intendedBoostGP && gainCountGP === 0) {
-            const _atp = ["double_session", "miracle_cream", "twelfth_man", "relation_boost", "transfer_insider", "youth_coup", "rewind", "random_attr"];
-            const pick = _atp[Math.floor(Math.random() * _atp.length)];
+            const pick = ARC_TICKET_POOL[Math.floor(Math.random() * ARC_TICKET_POOL.length)];
             setTickets(prev => [...prev, { id: `t_arc_gp_${Date.now()}_${Math.random().toString(36).slice(2,6)}`, type: pick }]);
           }
           setArcStepQueue(q => [...q, {

--- a/src/data/storyArcs.js
+++ b/src/data/storyArcs.js
@@ -2,6 +2,9 @@ export const ARC_CATS = ["player","club","legacy"];
 
 export const ARC_CAT_LABELS = { player:"🧑 PLAYER", club:"🏟️ CLUB", legacy:"⭐ LEGACY" };
 
+/** Ticket types awarded when an arc reward is fully capped (player already at max OVR). */
+export const ARC_TICKET_POOL = ["double_session", "miracle_cream", "twelfth_man", "relation_boost", "transfer_insider", "youth_coup", "rewind", "random_attr"];
+
 export const STORY_ARCS = [
   // === PLAYER ARCS ===
   { id:"the_project", cat:"player", name:"The Project", icon:"🧪",


### PR DESCRIPTION
## Summary
- The same 8-item ticket pool array was copy-pasted 3 times in App.jsx (lines ~2397, ~3293, ~3421)
- Extracted to a single `ARC_TICKET_POOL` export in `storyArcs.js` alongside the other arc constants
- All 3 call sites now import and reference the shared constant
- Zero logic changes — pure deduplication

## Test plan
- [x] Build passes
- [ ] Verify arc rewards still grant tickets when capped at max OVR

🤖 Generated with [Claude Code](https://claude.com/claude-code)